### PR TITLE
deleted include Eigen

### DIFF
--- a/TMOZhongping15/TMOZhongping15.cpp
+++ b/TMOZhongping15/TMOZhongping15.cpp
@@ -32,8 +32,6 @@
 #undef EPS
 using namespace cv;
 
-#include <Eigen/Dense>
-
 #define CIELAB_NUM_CHANNELS 3
 #define GAUSSIAN_FILTER_SIZE 5
 #define INFINITE_SIGMA 400


### PR DESCRIPTION
Eigen jsem v této metodě vůbec nepoužil a proto jsem ho do CMakeLists nedal. Includoval jsem jej nějakým nedopatřením; opraveno.