### PR TITLE
CMakeLists: update link to the model storage

### DIFF
--- a/TMOXia18/CMakeLists.txt
+++ b/TMOXia18/CMakeLists.txt
@@ -45,7 +45,7 @@ LINK_LIBRARIES (
 message(STATUS "Downloading the pre-trained model for the TMOXia18 operator...")
 
 download_model(
-https://github.com/davidchocholaty/TMOXia18-model/raw/main/tmoxia18_model.zip
+https://github.com/cadik/TMS-storage/raw/main/TMOXia18/tmoxia18_model.zip
 )
 
 message(STATUS "Extracting the downloaded model ...")


### PR DESCRIPTION
This PR replaces the link to the model storage from the old link to a personal repository to the new official repository used as a Tone Mapping Studio storage for large files.