### PR TITLE
Fix TMOVideo crash

### DIFF
--- a/TMOCmd/TMOCmd.cpp
+++ b/TMOCmd/TMOCmd.cpp
@@ -286,7 +286,7 @@ int TMOCmd::main(int argc, char *argv[])
 						op[opindex]->SetImages(input, output);
 						op[opindex]->Transform();
 
-						outVideo.setTMOImageFrame(outVideo.getVideoWriterObject(), output);
+						outVideo.setTMOImageFrame(outVideo.getWriterRef(), output);
 						output.Close();
 					}
 				}
@@ -415,3 +415,4 @@ int TMOCmd::Bar(int part, int all)
 		printf("%2i%%\b\b\b", 100 * part / all);
 	return 0;
 }
+

--- a/tmolib/TMOVideo.cpp
+++ b/tmolib/TMOVideo.cpp
@@ -275,3 +275,7 @@ int TMOVideo::setVName(char *name)
   vName = name;
   return 0;
 }
+cv::VideoWriter& TMOVideo::getWriterRef()
+{
+    return writerObject;
+}

--- a/tmolib/TMOVideo.h
+++ b/tmolib/TMOVideo.h
@@ -45,6 +45,7 @@ public:
       virtual int createOutputVideoByName(const char *filename, int width, int height);
       virtual int setVName(char *name);
       virtual char *getVNameOut() { return vNameOut; }
+      cv::VideoWriter& getWriterRef();
 
       TMOVideo(const char *filename);
       TMOVideo();


### PR DESCRIPTION
Passing cv::VideoWriter by value causes a double destruct and a crash since the compiler inserts a `ud2` instruction. Fixed by returning a reference to the objkect instead. This happens only in TMOCmd video branch that passes individual frames to by processed via traditional `Transform` instead of `TransformVideo`.